### PR TITLE
Moved code to store on a specific status from the storage classes ont…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ When an idempotency key is enabled on a view function the calling client must sp
 ## Settings
 The following settings can be used to modify the behaviour of the idempotency key middleware.
 ```
+from idempotency_key import status
+
 IDEMPOTENCY_KEY = {
     # Specify the storage class to be used for idempotency keys
     # If not specified then defaults to 'idempotency_key.storage.MemoryKeyStorage'
@@ -87,5 +89,19 @@ IDEMPOTENCY_KEY = {
     # to occur before the thread gives up waiting. If a timeout occurs the middleware will return a HTTP_423_LOCKED 
     # response.
     'LOCKING_TIMEOUT': '0.1',
+    
+    # When the response is to be stored you have the option of deciding when this happens based on the responses
+    # status code. If the response status code matches one of the statuses below then it will be stored.
+    # The statuses specific below are the defaults used if this setting is not specified.
+    'STORE_ON_STATUSES': [
+        status.HTTP_200_OK,
+        status.HTTP_201_CREATED,
+        status.HTTP_202_ACCEPTED,
+        status.HTTP_203_NON_AUTHORITATIVE_INFORMATION,
+        status.HTTP_204_NO_CONTENT,
+        status.HTTP_205_RESET_CONTENT,
+        status.HTTP_206_PARTIAL_CONTENT,
+        status.HTTP_207_MULTI_STATUS,
+    ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ IDEMPOTENCY_KEY = {
     
     # When the response is to be stored you have the option of deciding when this happens based on the responses
     # status code. If the response status code matches one of the statuses below then it will be stored.
-    # The statuses specific below are the defaults used if this setting is not specified.
+    # The statuses below are the defaults used if this setting is not specified.
     'STORE_ON_STATUSES': [
         status.HTTP_200_OK,
         status.HTTP_201_CREATED,

--- a/idempotency_key/middleware.py
+++ b/idempotency_key/middleware.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from idempotency_key.exceptions import DecoratorsMutuallyExclusiveError, bad_request, resource_locked
 from idempotency_key.utils import get_storage_class, get_encoder_class, get_conflict_code, get_lock_timeout, \
-    get_enable_lock
+    get_enable_lock, get_store_on_statuses
 
 logger = logging.getLogger('django-idempotency-key.idempotency_key.middleware')
 
@@ -153,7 +153,7 @@ class IdempotencyKeyMiddleware:
 
         if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
             # If the response matches that given by the store_on_statuses function then store the data
-            if response.status_code in self.storage.store_on_statuses():
+            if response.status_code in get_store_on_statuses():
                 self.storage.store_data(request.idempotency_key_encoded_key, response)
 
         return response

--- a/idempotency_key/utils.py
+++ b/idempotency_key/utils.py
@@ -40,3 +40,19 @@ def get_lock_timeout():
 def get_enable_lock():
     idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
     return idkey_settings.get('ENABLE_LOCK', True)
+
+
+def get_store_on_statuses():
+    idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
+    return idkey_settings.get(
+        'STORE_ON_STATUSES', [
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+            status.HTTP_202_ACCEPTED,
+            status.HTTP_203_NON_AUTHORITATIVE_INFORMATION,
+            status.HTTP_204_NO_CONTENT,
+            status.HTTP_205_RESET_CONTENT,
+            status.HTTP_206_PARTIAL_CONTENT,
+            status.HTTP_207_MULTI_STATUS,
+        ]
+    )

--- a/tests/tests/test_middleware.py
+++ b/tests/tests/test_middleware.py
@@ -8,7 +8,7 @@ import pytest
 from idempotency_key import status
 from idempotency_key.encoders import IdempotencyKeyEncoder
 from idempotency_key.exceptions import DecoratorsMutuallyExclusiveError
-from idempotency_key.storage import IdempotencyKeyStorage, MemoryKeyStorage
+from idempotency_key.storage import IdempotencyKeyStorage
 from tests.tests.utils import for_all_methods
 
 
@@ -39,16 +39,6 @@ class MyStorage(IdempotencyKeyStorage):
 
     def retrieve_data(self, encoded_key: str) -> Tuple[bool, object]:
         return False, None
-
-
-class TestStatus207Storage(MemoryKeyStorage):
-    def store_on_statuses(self):
-        return [status.HTTP_207_MULTI_STATUS]
-
-
-class TestStatus201Storage(MemoryKeyStorage):
-    def store_on_statuses(self):
-        return [status.HTTP_201_CREATED]
 
 
 @for_all_methods(set_middleware)
@@ -328,7 +318,7 @@ class TestMiddlewareInclusive:
         assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus207Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_207_MULTI_STATUS]},
     )
     def test_store_on_statuses_does_not_store(self, client):
         voucher_data = {
@@ -349,7 +339,7 @@ class TestMiddlewareInclusive:
         assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus201Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_201_CREATED]},
     )
     def test_store_on_statuses_does_store(self, client):
         voucher_data = {

--- a/tests/tests/test_middleware_exempt.py
+++ b/tests/tests/test_middleware_exempt.py
@@ -290,7 +290,7 @@ class TestMiddlewareExempt:
         assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus207Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_207_MULTI_STATUS]},
     )
     def test_store_on_statuses_does_not_store(self, client):
         voucher_data = {
@@ -311,7 +311,7 @@ class TestMiddlewareExempt:
         assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus201Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_201_CREATED]},
     )
     def test_store_on_statuses_does_store(self, client):
         voucher_data = {

--- a/tests/tests/test_middleware_exempt_viewsets.py
+++ b/tests/tests/test_middleware_exempt_viewsets.py
@@ -330,7 +330,7 @@ class TestMiddlewareExemptViewSets:
         assert hasattr(request, 'idempotency_key_encoded_key') is False
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus207Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_207_MULTI_STATUS]},
     )
     def test_store_on_statuses_does_not_store(self, client):
         voucher_data = {
@@ -351,7 +351,7 @@ class TestMiddlewareExemptViewSets:
         assert request.idempotency_key_encoded_key == '814ed44a059114973f1cb334a542eb18a52923adc531d66b5e62479f29c2da6a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus201Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_201_CREATED]},
     )
     def test_store_on_statuses_does_store(self, client):
         voucher_data = {

--- a/tests/tests/test_middleware_viewsets.py
+++ b/tests/tests/test_middleware_viewsets.py
@@ -359,7 +359,7 @@ class TestMiddlewareInclusive:
         assert hasattr(request, 'idempotency_key_encoded_key') is False
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus207Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_207_MULTI_STATUS]},
     )
     def test_store_on_statuses_does_not_store(self, client):
         voucher_data = {
@@ -380,7 +380,7 @@ class TestMiddlewareInclusive:
         assert request.idempotency_key_encoded_key == '814ed44a059114973f1cb334a542eb18a52923adc531d66b5e62479f29c2da6a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORAGE_CLASS': 'tests.tests.test_middleware.TestStatus201Storage'},
+        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_201_CREATED]},
     )
     def test_store_on_statuses_does_store(self, client):
         voucher_data = {


### PR DESCRIPTION
The statuses used to determine if the response should be stored has been moved from the storage class function store_on_statuses() to the settings under STORE_ON_STATUSES. This change was made because there can be only one storage class in use, therefore, moving this into the settings file makes more sense.