### PR TITLE
B2B-94 customizable cache per view function

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ djangorestframework = "*"
 django-debug-toolbar = "==1.10.1"
 codecov = "*"
 redis = "*"
+django-redis = "*"
 
 [packages]
 django = "~=1.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33613f8b598437847cf7534a50130d8f2e553c9ed34dc287906d21b2d71f9a75"
+            "sha256": "34cfe7f7c7d7cd88576c323ef147213f11ef709dd1da734c7072eb0ef4ee7bac"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -154,6 +154,14 @@
             ],
             "index": "pypi",
             "version": "==1.10.1"
+        },
+        "django-redis": {
+            "hashes": [
+                "sha256:af0b393864e91228dd30d8c85b5c44d670b5524cb161b7f9e41acc98b6e5ace7",
+                "sha256:f46115577063d00a890867c6964ba096057f07cb756e78e0503b89cd18e4e083"
+            ],
+            "index": "pypi",
+            "version": "==4.10.0"
         },
         "djangorestframework": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ The following settings can be used to modify the behaviour of the idempotency ke
 from idempotency_key import status
 
 IDEMPOTENCY_KEY = {
-    # Specify the storage class to be used for idempotency keys
-    # If not specified then defaults to 'idempotency_key.storage.MemoryKeyStorage'
-    'STORAGE_CLASS': 'idempotency_key.storage.MemoryKeyStorage',
-
     # Specify the key encoder class to be used for idempotency keys.
     # If not specified then defaults to 'idempotency_key.encoders.BasicKeyEncoder'
     'ENCODER_CLASS': 'idempotency_key.encoders.BasicKeyEncoder',
@@ -78,23 +74,30 @@ IDEMPOTENCY_KEY = {
     # If not specified this defaults to HTTP_409_CONFLICT
     # If set to None then the original request's status code is used.
     'CONFLICT_STATUS_CODE': status.HTTP_409_CONFLICT,
-    
-    # Name of the django cache configuration to use for the CacheStorageKey storage class
-    'CACHE_NAME': 'default',
-       
-    # When the response is to be stored you have the option of deciding when this happens based on the responses
-    # status code. If the response status code matches one of the statuses below then it will be stored.
-    # The statuses below are the defaults used if this setting is not specified.
-    'STORE_ON_STATUSES': [
-        status.HTTP_200_OK,
-        status.HTTP_201_CREATED,
-        status.HTTP_202_ACCEPTED,
-        status.HTTP_203_NON_AUTHORITATIVE_INFORMATION,
-        status.HTTP_204_NO_CONTENT,
-        status.HTTP_205_RESET_CONTENT,
-        status.HTTP_206_PARTIAL_CONTENT,
-        status.HTTP_207_MULTI_STATUS,
-    ]
+
+    'STORAGE': {
+        # Specify the storage class to be used for idempotency keys
+        # If not specified then defaults to 'idempotency_key.storage.MemoryKeyStorage'
+        'CLASS': 'idempotency_key.storage.MemoryKeyStorage',
+
+        # Name of the django cache configuration to use for the CacheStorageKey storage class.
+        # This can be overriden using the @idempotency_key(cache_name='MyCacheName') view/viewset function decorator.
+        'CACHE_NAME': 'default',
+
+        # When the response is to be stored you have the option of deciding when this happens based on the responses
+        # status code. If the response status code matches one of the statuses below then it will be stored.
+        # The statuses below are the defaults used if this setting is not specified.
+        'STORE_ON_STATUSES': [
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+            status.HTTP_202_ACCEPTED,
+            status.HTTP_203_NON_AUTHORITATIVE_INFORMATION,
+            status.HTTP_204_NO_CONTENT,
+            status.HTTP_205_RESET_CONTENT,
+            status.HTTP_206_PARTIAL_CONTENT,
+            status.HTTP_207_MULTI_STATUS,
+        ]
+    }
 
     # The following settings deal with the process/thread lock that can be placed around the cache storage object
     # to ensure that multiple threads do not try to call the same view/viewset method at the same time.

--- a/idempotency_key/decorators.py
+++ b/idempotency_key/decorators.py
@@ -1,5 +1,7 @@
 from functools import wraps
 
+from idempotency_key import utils
+
 
 # NOTE:
 # The following decorators must be specified BEFORE the @api_view decorator or the function will not be marked
@@ -17,10 +19,11 @@ def idempotency_key(*args, cache_name=None):
     """
     Allows an optional cache name to be specified so that different cache settings can be used on a per-view function
     basis.
-    :param args: optioanl arguments. This can contain the view function object if cache_name is not specified
+    :param args: optional arguments. This can contain the view function object if cache_name is not specified
     :param cache_name: The name of the cache to use from the settings file under CACHES={...}
     :return: wrapped function
     """
+
     def _idempotency_key(view_func):
         """
         Mark a view function as requiring idempotency key protection but the view should control the response.
@@ -31,9 +34,12 @@ def idempotency_key(*args, cache_name=None):
             return view_func(*args, **kwargs)
 
         wrapped_view.idempotency_key = True
+
         if cache_name:
             wrapped_view.idempotency_key_cache_name = cache_name
-        return wraps(view_func)(wrapped_view)
+            utils.get_storage_class().validate_storage(cache_name)
+
+        return wrapped_view
 
     # if there is an argument passed and it is a callable then this will be the view function object so pass it to
     # the wrapper

--- a/idempotency_key/decorators.py
+++ b/idempotency_key/decorators.py
@@ -14,11 +14,19 @@ from functools import wraps
 
 
 def idempotency_key(*args, cache_name=None):
+    """
+    Allows an optional cache name to be specified so that different cache settings can be used on a per-view function
+    basis.
+    :param args: optioanl arguments. This can contain the view function object if cache_name is not specified
+    :param cache_name: The name of the cache to use from the settings file under CACHES={...}
+    :return: wrapped function
+    """
     def _idempotency_key(view_func):
         """
         Mark a view function as requiring idempotency key protection but the view should control the response.
         """
 
+        @wraps(view_func)
         def wrapped_view(*args, **kwargs):
             return view_func(*args, **kwargs)
 
@@ -27,8 +35,12 @@ def idempotency_key(*args, cache_name=None):
             wrapped_view.idempotency_key_cache_name = cache_name
         return wraps(view_func)(wrapped_view)
 
+    # if there is an argument passed and it is a callable then this will be the view function object so pass it to
+    # the wrapper
     if len(args) > 0 and callable(args[0]):
         return _idempotency_key(args[0])
+
+    # otherwise just return the wrapper object
     return _idempotency_key
 
 

--- a/idempotency_key/decorators.py
+++ b/idempotency_key/decorators.py
@@ -13,16 +13,23 @@ from functools import wraps
 #   ...
 
 
-def idempotency_key(view_func):
-    """
-    Mark a view function as requiring idempotency key protection but the view should control the response.
-    """
+def idempotency_key(*args, cache_name=None):
+    def _idempotency_key(view_func):
+        """
+        Mark a view function as requiring idempotency key protection but the view should control the response.
+        """
 
-    def wrapped_view(*args, **kwargs):
-        return view_func(*args, **kwargs)
+        def wrapped_view(*args, **kwargs):
+            return view_func(*args, **kwargs)
 
-    wrapped_view.idempotency_key = True
-    return wraps(view_func)(wrapped_view)
+        wrapped_view.idempotency_key = True
+        if cache_name:
+            wrapped_view.idempotency_key_cache_name = cache_name
+        return wraps(view_func)(wrapped_view)
+
+    if len(args) > 0 and callable(args[0]):
+        return _idempotency_key(args[0])
+    return _idempotency_key
 
 
 def idempotency_key_exempt(view_func):

--- a/idempotency_key/storage.py
+++ b/idempotency_key/storage.py
@@ -42,10 +42,7 @@ class MemoryKeyStorage(IdempotencyKeyStorage):
 
     def retrieve_data(self, cache_name: str, encoded_key: str) -> Tuple[bool, object]:
         the_cache = self.idempotency_key_cache_data.get(cache_name)
-        if the_cache is None:
-            return False, None
-
-        if encoded_key in the_cache.keys():
+        if the_cache and encoded_key in the_cache.keys():
             return True, the_cache[encoded_key]
 
         return False, None

--- a/idempotency_key/utils.py
+++ b/idempotency_key/utils.py
@@ -26,20 +26,22 @@ def get_conflict_code():
     return get_idempotency_key_settings().get('CONFLICT_STATUS_CODE', status.HTTP_409_CONFLICT)
 
 
+def get_storage_settings():
+    return get_idempotency_key_settings().get('STORAGE', dict())
+
+
 def get_storage_class():
-    return module_loading.import_string(get_idempotency_key_settings().get(
-        'STORAGE_CLASS', 'idempotency_key.storage.MemoryKeyStorage')
+    return module_loading.import_string(get_storage_settings().get(
+        'CLASS', 'idempotency_key.storage.MemoryKeyStorage')
     )
 
+
 def get_storage_cache_name():
-    storage_settings = get_idempotency_key_settings().get('STORAGE', dict())
-    return storage_settings.get('CACHE_NAME', 'default')
+    return get_storage_settings().get('CACHE_NAME', 'default')
 
 
 def get_storage_store_on_statuses():
-    idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
-    storage_settings = idkey_settings.get('STORAGE', dict())
-    return storage_settings.get(
+    return get_storage_settings().get(
         'STORE_ON_STATUSES', [
             status.HTTP_200_OK,
             status.HTTP_201_CREATED,
@@ -51,8 +53,6 @@ def get_storage_store_on_statuses():
             status.HTTP_207_MULTI_STATUS,
         ]
     )
-def get_cache_name():
-    return get_idempotency_key_settings().get('CACHE_NAME', 'default')
 
 
 def get_lock_settings():

--- a/idempotency_key/utils.py
+++ b/idempotency_key/utils.py
@@ -12,11 +12,6 @@ def idempotency_key_response(request):
     return getattr(request, 'idempotency_key_response', None)
 
 
-def get_storage_class():
-    idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
-    return module_loading.import_string(idkey_settings.get('STORAGE_CLASS', 'idempotency_key.storage.MemoryKeyStorage'))
-
-
 def get_encoder_class():
     idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
     return module_loading.import_string(idkey_settings.get('ENCODER_CLASS', 'idempotency_key.encoders.BasicKeyEncoder'))
@@ -27,9 +22,33 @@ def get_conflict_code():
     return idkey_settings.get('CONFLICT_STATUS_CODE', status.HTTP_409_CONFLICT)
 
 
-def get_cache_name():
+def get_storage_class():
     idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
-    return idkey_settings.get('CACHE_NAME', 'default')
+    storage_settings = idkey_settings.get('STORAGE', dict())
+    return module_loading.import_string(storage_settings.get('CLASS', 'idempotency_key.storage.MemoryKeyStorage'))
+
+
+def get_storage_cache_name():
+    idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
+    storage_settings = idkey_settings.get('STORAGE', dict())
+    return storage_settings.get('CACHE_NAME', 'default')
+
+
+def get_storage_store_on_statuses():
+    idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
+    storage_settings = idkey_settings.get('STORAGE', dict())
+    return storage_settings.get(
+        'STORE_ON_STATUSES', [
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+            status.HTTP_202_ACCEPTED,
+            status.HTTP_203_NON_AUTHORITATIVE_INFORMATION,
+            status.HTTP_204_NO_CONTENT,
+            status.HTTP_205_RESET_CONTENT,
+            status.HTTP_206_PARTIAL_CONTENT,
+            status.HTTP_207_MULTI_STATUS,
+        ]
+    )
 
 
 def get_lock_class():
@@ -60,19 +79,3 @@ def get_lock_name():
     idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
     lock_settings = idkey_settings['LOCK'] if 'LOCK' in idkey_settings else dict()
     return lock_settings.get('NAME', 'MyLock')
-
-
-def get_store_on_statuses():
-    idkey_settings = getattr(settings, 'IDEMPOTENCY_KEY', dict())
-    return idkey_settings.get(
-        'STORE_ON_STATUSES', [
-            status.HTTP_200_OK,
-            status.HTTP_201_CREATED,
-            status.HTTP_202_ACCEPTED,
-            status.HTTP_203_NON_AUTHORITATIVE_INFORMATION,
-            status.HTTP_204_NO_CONTENT,
-            status.HTTP_205_RESET_CONTENT,
-            status.HTTP_206_PARTIAL_CONTENT,
-            status.HTTP_207_MULTI_STATUS,
-        ]
-    )

--- a/tests/tests/test_middleware.py
+++ b/tests/tests/test_middleware.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import Tuple
 
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.test import modify_settings, override_settings
 import pytest
 
@@ -34,10 +34,10 @@ class MyStorage(IdempotencyKeyStorage):
     def __init__(self):
         self.idempotency_key_cache_data = dict()
 
-    def store_data(self, encoded_key: str, response: object) -> None:
+    def store_data(self, cache_name: str, encoded_key: str, response: object) -> None:
         pass
 
-    def retrieve_data(self, encoded_key: str) -> Tuple[bool, object]:
+    def retrieve_data(self, cache_name: str, encoded_key: str) -> Tuple[bool, object]:
         return False, None
 
 
@@ -47,7 +47,7 @@ class TestMiddlewareInclusive:
     urls = {
         name: '/views/{}/'.format(name) for name in
         ['get', 'create', 'create-exempt', 'create-no-decorators', 'create-manual', 'create-exempt-test-1',
-         'create-exempt-test-2', 'create-manual-exempt-1', 'create-manual-exempt-2']
+         'create-exempt-test-2', 'create-manual-exempt-1', 'create-manual-exempt-2', 'create-with-my-cache']
     }
 
     def test_get_exempt(self, client):
@@ -222,9 +222,7 @@ class TestMiddlewareInclusive:
         assert request.idempotency_key_encoded_key == '0000000000000000000000000000000000000000000000000000000000000000'
 
     @override_settings(
-        IDEMPOTENCY_KEY={
-            'STORAGE_CLASS': 'tests.tests.test_middleware.MyStorage'
-        }
+        IDEMPOTENCY_KEY={'STORAGE': {'CLASS': 'tests.tests.test_middleware.MyStorage'}, }
     )
     def test_middleware_custom_storage(self, client):
         """
@@ -318,7 +316,7 @@ class TestMiddlewareInclusive:
         assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
 
     @override_settings(
-        IDEMPOTENCY_KEY={'STORE_ON_STATUSES': [status.HTTP_207_MULTI_STATUS]},
+        IDEMPOTENCY_KEY={'STORAGE': {'STORE_ON_STATUSES': [status.HTTP_207_MULTI_STATUS]}, },
     )
     def test_store_on_statuses_does_not_store(self, client):
         voucher_data = {
@@ -380,3 +378,70 @@ class TestMiddlewareInclusive:
         assert request.idempotency_key_exempt is False
         assert request.idempotency_key_manual is False
         assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
+
+    @override_settings(
+        IDEMPOTENCY_KEY={
+            'STORAGE': {
+                'CLASS': 'idempotency_key.storage.CacheKeyStorage',
+                'CACHE_NAME': 'SevenDayCache',  # This should be overridden by the decorator
+            },
+        },
+    )
+    def test_middleware_cache_storage_using_custom_cache_name_on_decorator(self, client):
+        """
+        Tests @idempotency_key(cache_name='FiveMinuteCache') decorator
+        """
+        caches['default'].clear()
+        caches['FiveMinuteCache'].clear()
+        voucher_data = {
+            'id': 1,
+            'name': 'myvoucher0',
+            'internal_name': 'myvoucher0',
+        }
+
+        response = client.post(self.urls['create-with-my-cache'], voucher_data, secure=True,
+                               HTTP_IDEMPOTENCY_KEY=self.the_key)
+        assert status.HTTP_201_CREATED == response.status_code
+
+        response2 = client.post(self.urls['create-with-my-cache'], voucher_data, secure=True,
+                                HTTP_IDEMPOTENCY_KEY=self.the_key)
+        assert response2.status_code == status.HTTP_409_CONFLICT
+        request = response2.wsgi_request
+        assert request.idempotency_key_exists is True
+        assert request.idempotency_key_response == response2
+        assert request.idempotency_key_exempt is False
+        assert request.idempotency_key_manual is False
+        assert request.idempotency_key_encoded_key == '380d507306731904a70650014cedaa4859ef38d9cdd4ff537dea410f2bee324d'
+        assert request.idempotency_key_cache_name == 'FiveMinuteCache'
+
+    @override_settings(
+        IDEMPOTENCY_KEY={
+            'STORAGE': {
+                'CLASS': 'idempotency_key.storage.CacheKeyStorage',
+                'CACHE_NAME': 'FiveMinuteCache',  # This should be overridden by the decorator
+            },
+        },
+    )
+    def test_middleware_storage_cache_name_provides_default_name(self, client):
+        """
+        Tests @idempotency_key(cache_name='FiveMinuteCache') decorator
+        """
+        caches['FiveMinuteCache'].clear()
+        voucher_data = {
+            'id': 1,
+            'name': 'myvoucher0',
+            'internal_name': 'myvoucher0',
+        }
+
+        response = client.post(self.urls['create'], voucher_data, secure=True, HTTP_IDEMPOTENCY_KEY=self.the_key)
+        assert response.status_code == status.HTTP_201_CREATED
+
+        response2 = client.post(self.urls['create'], voucher_data, secure=True, HTTP_IDEMPOTENCY_KEY=self.the_key)
+        assert response2.status_code == status.HTTP_409_CONFLICT
+        request = response2.wsgi_request
+        assert request.idempotency_key_exists is True
+        assert request.idempotency_key_response == response2
+        assert request.idempotency_key_exempt is False
+        assert request.idempotency_key_manual is False
+        assert request.idempotency_key_encoded_key == 'f7a64a46c05113ce5828b8df7230c27e19e5934419c07b2feed9a52ba7bdbd5a'
+        assert request.idempotency_key_cache_name == 'FiveMinuteCache'

--- a/tests/tests/test_storage.py
+++ b/tests/tests/test_storage.py
@@ -23,9 +23,20 @@ def test_memory_storage_retrieve():
     assert value == 'value'
 
 
+def test_memory_storage_cache_name_not_present():
+    cache_name = 'default'
+    obj = MemoryKeyStorage()
+    key_exists, value = obj.retrieve_data(cache_name, 'key')
+    assert key_exists is False
+    assert value is None
+
+
 def test_memory_storage_retrieve_no_key():
     cache_name = 'default'
     obj = MemoryKeyStorage()
+    # This creates a cache with name default and adds a dummy key:value pair
+    obj.store_data(cache_name, 'somekey', None)
+    # now try to get a key that does not exist
     key_exists, value = obj.retrieve_data(cache_name, 'key')
     assert key_exists is False
     assert value is None

--- a/tests/tests/test_storage_locking.py
+++ b/tests/tests/test_storage_locking.py
@@ -5,6 +5,7 @@ from idempotency_key.middleware import IdempotencyKeyMiddleware
 def test_storage_when_locked_returns_423():
     class Request:
         idempotency_key_manual = False
+        idempotency_key_cache_name = 'default'
         pass
 
     request = Request()

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -43,12 +43,10 @@ def test_idempotency_key_response_object():
 
 
 @override_settings(
-    IDEMPOTENCY_KEY={
-        'STORE_ON_STATUSES': [status.HTTP_200_OK]
-    }
+    IDEMPOTENCY_KEY={'STORAGE': {'STORE_ON_STATUSES': [status.HTTP_200_OK]}, }
 )
 def test_get_store_on_statuses_default():
-    assert utils.get_store_on_statuses() == [
+    assert utils.get_storage_store_on_statuses() == [
         status.HTTP_200_OK
     ]
 
@@ -57,7 +55,7 @@ def test_get_store_on_statuses_default():
     IDEMPOTENCY_KEY={}
 )
 def test_get_store_on_statuses_not_specified():
-    assert utils.get_store_on_statuses() == [
+    assert utils.get_storage_store_on_statuses() == [
         status.HTTP_200_OK,
         status.HTTP_201_CREATED,
         status.HTTP_202_ACCEPTED,

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     url(r'^views/create-no-decorators/$', views.create_no_decorators),
     url(r'^views/create-manual-exempt-1/$', views.create_manual_exempt_1),
     url(r'^views/create-manual-exempt-2/$', views.create_manual_exempt_2),
+    url(r'^views/create-with-my-cache/$', views.create_with_my_cache),
 
     url(r'^viewsets/get/$', MyViewSet.as_view({'get': 'get'})),
     url(r'^viewsets/create/$', MyViewSet.as_view({'post': 'create'})),
@@ -42,7 +43,10 @@ urlpatterns = [
     url(r'^viewsets/create-no-decorators/$', MyViewSet.as_view({'post': 'create_no_decorators'})),
     url(r'^viewsets/create-manual-exempt-1/$', MyViewSet.as_view({'post': 'create_manual_exempt_1'})),
     url(r'^viewsets/create-manual-exempt-2/$', MyViewSet.as_view({'post': 'create_manual_exempt_2'})),
+    url(r'^viewsets/create-with-my-cache/$', MyViewSet.as_view({'post': 'create_with_my_cache'})),
+
     url(r'^viewsets/create-nested-decorator/$', MyViewSet2.as_view({'post': 'create'})),
+
     url(r'^viewsets/create-nested-decorator-exempt/$', MyViewSet2Exempt.as_view({'post': 'create'})),
 
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -65,3 +65,9 @@ def create_manual_exempt_1(request, *args, **kwargs):
 @api_view(['POST'])
 def create_manual_exempt_2(request, *args, **kwargs):
     return Response(status=201, data={})
+
+
+@idempotency_key(cache_name='FiveMinuteCache')
+@api_view(['POST'])
+def create_with_my_cache(request, *args, **kwargs):
+    return Response(status=201, data={})

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -53,6 +53,10 @@ class MyViewSet(ViewSet):
     def create_manual_exempt_2(self, request, *args, **kwargs):
         return Response(status=201, data={})
 
+    @idempotency_key(cache_name='FiveMinuteCache')
+    def create_with_my_cache(self, request, *args, **kwargs):
+        return Response(status=201, data={})
+
 
 class MyModelViewSet(ViewSet):
     def create(self, request, *args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,7 @@ deps =
     django2: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     redis>=3.0
+    django-redis>=4.0
+
 commands =
     py.test {posargs}


### PR DESCRIPTION
Allow the developer to choose the cache_name via the @idempotency_key decorator so that different cache settings can be used based on the view/viewset function.
This will allow one view function to have a cache TTL of 5 minutes for transactions but a cache TTL of 7 days for loyalty views.