### PR TITLE
Add check for importing Redis module

### DIFF
--- a/idempotency_key/locks.py
+++ b/idempotency_key/locks.py
@@ -1,9 +1,10 @@
 import abc
 import threading
 
-from redis import Redis
-
 from idempotency_key import utils
+
+if utils.get_lock_settings().get('CLASS', 'idempotency_key.locks.ThreadLock') == "idempotency_key.locks.MultiProcessRedisLock":
+    from redis import Redis
 
 
 class IdempotencyKeyLock(abc.ABC):


### PR DESCRIPTION
Current version requires the Redis module in order to run. By adding a check for which Lock is used in SETTINGS, Redis is only imported if MultiProcessRedisLock is used.