### PR TITLE
Fix packaging

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = False
 tag = False
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,10 @@ updating.
 **[Breaking changes]** - There are changes that break existing compatibility.
 
 ---
+# 1.1.1
+- Fixed a problem with packaging on release where the new locks folder was missing.
+
+---
 # 1.1.0
   **[Security updates]**
    

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,11 @@ coverage:
 
 bundle: static_analysis coverage
 	rm -r ./dist/ || true
+	rm -r ./django_idempotency_key.egg-info/ || true
 	python setup.py sdist
 
 release-test:
-	twine upload --repository-url https://test.pypi.org/legacy/ dist/django-idempotency-key-1.1.0.tar.gz
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/django-idempotency-key-1.1.1.tar.gz
 
 release: static_analysis coverage
 	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ coverage:
 	@echo file://${PWD}/htmlcov/index.html
 
 bundle: static_analysis coverage
-	rm -r ./dist/
+	rm -r ./dist/ || true
 	python setup.py sdist
 
 release-test:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="django-idempotency-key",
-    version="1.1.0",
+    version="1.1.1",
     author="Del Hyman-Jones",
     author_email="dev@yoyowallet.com",
     description=(
@@ -32,14 +32,14 @@ setup(
         "Framework :: Django :: 2.2",
         "Programming Language :: Python :: 3.6",
     ],
-    install_requires=["Django>=2.0"],
+    install_requires=["Django>=2.0,<3"],
     project_urls={
         "Documentation": (
             "https://github.com/yoyowallet/django-idempotency-key/blob/master/README.md"
         ),
         "Source": "https://github.com/yoyowallet/django-idempotency-key",
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     setup_requires=["setuptools>=38.6.0"],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open("README.md") as f:
     long_description = f.read()
@@ -39,7 +39,7 @@ setup(
         ),
         "Source": "https://github.com/yoyowallet/django-idempotency-key",
     },
-    packages=["idempotency_key"],
+    packages=find_packages(),
     setup_requires=["setuptools>=38.6.0"],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
- fixed issue where the locks folder and its content was not being added to the package.
- `make bundle` no longer fails if the removal of the dist folder fails.
- Delete the `django_idempotency_key.egg-info` folder because it was overriding our code.
- Exclude tests folder in the final package.
- Changed install_requires so that Django 3 is not supported.
- bump version to 1.1.1
- Updated changes log