### PR TITLE
Added authorisation header to BasicKeyEncoder. pre-commit chores.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 repos:
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 23.1.0
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.4.0
   hooks:
   - id: check-added-large-files
   - id: check-ast

--- a/idempotency_key/decorators.py
+++ b/idempotency_key/decorators.py
@@ -3,8 +3,8 @@ from functools import wraps
 from idempotency_key import utils
 
 # NOTE:
-# The following decorators must be specified BEFORE the @api_view decorator or the function will not be marked
-# correctly.
+# The following decorators must be specified BEFORE the @api_view decorator or the
+# function will not be marked correctly.
 #
 # i.e:
 #
@@ -16,17 +16,20 @@ from idempotency_key import utils
 
 def idempotency_key(*args, optional=False, cache_name=None):
     """
-    Allows an optional cache name to be specified so that different cache settings can be used on a per-view function
-    basis.
-    :param args: optional arguments. This can contain the view function object if cache_name is not specified
+    Allows an optional cache name to be specified so that different cache settings
+    can be used on a per-view function basis.
+    :param args: optional arguments. This can contain the view function object if
+        cache_name is not specified
     :param optional: Mark idempotency key header as optional
-    :param cache_name: The name of the cache to use from the settings file under CACHES={...}
+    :param cache_name: The name of the cache to use from the settings file under
+        CACHES={...}
     :return: wrapped function
     """
 
     def _idempotency_key(view_func):
         """
-        Mark a view function as requiring idempotency key protection but the view should control the response.
+        Mark a view function as requiring idempotency key protection but the view
+        should control the response.
         """
 
         @wraps(view_func)
@@ -42,8 +45,8 @@ def idempotency_key(*args, optional=False, cache_name=None):
 
         return wrapped_view
 
-    # if there is an argument passed and it is a callable then this will be the view function object so pass it to
-    # the wrapper
+    # if there is an argument passed and it is a callable then this will be the
+    # view function object so pass it to the wrapper
     if len(args) > 0 and callable(args[0]):
         return _idempotency_key(args[0])
 
@@ -65,7 +68,8 @@ def idempotency_key_exempt(view_func):
 
 def idempotency_key_manual(view_func):
     """
-    Mark a view function as requiring idempotency key protection but the view should control the response.
+    Mark a view function as requiring idempotency key protection but the view
+    should control the response.
     """
 
     def wrapped_view(*args, **kwargs):

--- a/idempotency_key/encoders.py
+++ b/idempotency_key/encoders.py
@@ -1,6 +1,8 @@
 import abc
 import hashlib
 
+from django.http.request import HttpRequest
+
 from idempotency_key.exceptions import MissingIdempotencyKeyError
 
 
@@ -11,7 +13,7 @@ class IdempotencyKeyEncoder(object):
 
 
 class BasicKeyEncoder(IdempotencyKeyEncoder):
-    def encode_key(self, request, key):
+    def encode_key(self, request: HttpRequest, key):
         if key is None:
             raise MissingIdempotencyKeyError()
         # Basic method for generating an encoded key
@@ -20,4 +22,7 @@ class BasicKeyEncoder(IdempotencyKeyEncoder):
         m.update(request.path_info.encode("UTF-8"))
         m.update(request.method.encode("UTF-8"))
         m.update(request.body)
+        if request.META.get("HTTP_AUTHORIZATION"):
+            m.update(request.META.get("HTTP_AUTHORIZATION").encode("UTF-8"))
+
         return m.hexdigest()

--- a/idempotency_key/middleware.py
+++ b/idempotency_key/middleware.py
@@ -56,7 +56,9 @@ class IdempotencyKeyMiddleware:
         idempotency_key_exempt = getattr(callback, "idempotency_key_exempt", False)
         idempotency_key_manual = getattr(callback, "idempotency_key_manual", False)
         idempotency_key_cache_name = getattr(
-            callback, "idempotency_key_cache_name", utils.get_storage_cache_name()
+            callback,
+            "idempotency_key_cache_name",
+            utils.get_storage_cache_name(),
         )
 
         if idempotency_key and idempotency_key_exempt:
@@ -229,7 +231,9 @@ class ExemptIdempotencyKeyMiddleware(IdempotencyKeyMiddleware):
         idempotency_key_exempt = getattr(callback, "idempotency_key_exempt", None)
         idempotency_key_manual = getattr(callback, "idempotency_key_manual", False)
         idempotency_key_cache_name = getattr(
-            callback, "idempotency_key_cache_name", utils.get_storage_cache_name()
+            callback,
+            "idempotency_key_cache_name",
+            utils.get_storage_cache_name(),
         )
 
         if idempotency_key and idempotency_key_exempt:

--- a/idempotency_key/storage.py
+++ b/idempotency_key/storage.py
@@ -32,8 +32,9 @@ class IdempotencyKeyStorage(object):
     @abc.abstractmethod
     def validate_storage(name: str):
         """
-        Validate that the storage name exists. If the class is using django `CACHES` setting then this function ensures
-        that the cache is setup correctly in the settings file and will cause a failure at startup if it is not.
+        Validate that the storage name exists. If the class is using django `CACHES`
+        setting then this function ensures that the cache is setup correctly in the
+        settings file and will cause a failure at startup if it is not.
         This function should raise an exception if the storage name cannot be validated.
         :param name: The name of the storage.
         """
@@ -73,6 +74,7 @@ class CacheKeyStorage(IdempotencyKeyStorage):
 
     @staticmethod
     def validate_storage(name: str):
-        # Check that the cache exists. If the cache is not found then an InvalidCacheBackendError is raised.
-        # Not that there is no get function on the caches object so we cannot perform a normal check.
+        # Check that the cache exists. If the cache is not found then an
+        # InvalidCacheBackendError is raised. Not that there is no get function
+        # on the caches object so we cannot perform a normal check.
         caches[name]

--- a/poetry.lock
+++ b/poetry.lock
@@ -10,7 +10,7 @@ python-versions = ">=3.7"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "async-timeout"
@@ -40,10 +40,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy", "six", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy", "six", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
-dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy", "six", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "black"
@@ -63,10 +63,10 @@ typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implem
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-uvloop = ["uvloop (>=0.15.2)"]
-jupyter = ["tokenize-rt (>=3.2.0)", "ipython (>=7.8.0)"]
-d = ["aiohttp (>=3.7.4)"]
 colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleach"
@@ -81,8 +81,7 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
-dev = ["mypy (==0.942)", "black (==22.3.0)", "hashin (==0.17.0)", "wheel (==0.37.1)", "twine (==4.0.0)", "sphinx (==4.3.2)", "tox (==3.24.5)", "flake8 (==4.0.1)", "pytest (==7.1.1)", "pip-tools (==6.5.1)"]
-css = ["tinycss2 (>=1.1.0)"]
+dev = ["black (==22.3.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "mypy (==0.942)", "pip-tools (==6.5.1)", "pytest (==7.1.1)", "sphinx (==4.3.2)", "tox (==3.24.5)", "twine (==4.0.0)", "wheel (==0.37.1)"]
 
 [[package]]
 name = "bump2version"
@@ -128,7 +127,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -171,7 +170,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
@@ -199,12 +198,12 @@ python-versions = ">=3.6"
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx_rtd_theme"]
+docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
 name = "deprecated"
@@ -218,7 +217,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
+dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
 
 [[package]]
 name = "distlib"
@@ -242,8 +241,8 @@ pytz = "*"
 sqlparse = ">=0.2.2"
 
 [package.extras]
-bcrypt = ["bcrypt"]
 argon2 = ["argon2-cffi (>=19.1.0)"]
+bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-debug-toolbar"
@@ -358,8 +357,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-testing = ["importlib-resources (>=1.3)", "pytest-mypy", "pytest-black (>=0.3.7)", "flufl.flake8", "pyfakefs", "pep517", "packaging", "pytest-enabler (>=1.0.1)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=4.6)"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=8.2)", "sphinx"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -378,8 +377,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-trio = ["async-generator", "trio"]
-test = ["async-timeout", "trio", "testpath", "pytest-asyncio (>=0.17)", "pytest-trio", "pytest"]
+test = ["async-timeout", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["async_generator", "trio"]
 
 [[package]]
 name = "keyring"
@@ -396,8 +395,8 @@ pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_
 SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["jaraco.packaging (>=8.2)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "mando"
@@ -411,7 +410,7 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-restructuredText = ["rst2ansi"]
+restructuredtext = ["rst2ansi"]
 
 [[package]]
 name = "mccabe"
@@ -476,8 +475,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
-docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -491,12 +490,12 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.18.1"
+version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -508,8 +507,7 @@ identify = ">=1.0.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
-toml = "*"
-virtualenv = ">=20.0.8"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "py"
@@ -597,7 +595,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pytest-django"
@@ -611,8 +609,8 @@ python-versions = ">=3.5"
 pytest = ">=5.4.0"
 
 [package.extras]
-testing = ["django-configurations (>=2.0)", "django"]
-docs = ["sphinx-rtd-theme", "sphinx"]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
 name = "pytest-mock"
@@ -626,7 +624,7 @@ python-versions = ">=3.7"
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "tox", "pytest-asyncio"]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytz"
@@ -697,8 +695,8 @@ packaging = ">=20.4"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-ocsp = ["requests (>=2.26.0)", "pyopenssl (==20.0.1)", "cryptography (>=36.0.1)"]
 hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
 name = "requests"
@@ -715,8 +713,8 @@ idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
-socks = ["win-inet-pton", "PySocks (>=1.5.6,!=1.5.7)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -821,7 +819,7 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
-testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
 
 [[package]]
 name = "twine"
@@ -867,9 +865,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-secure = ["ipaddress", "certifi", "idna (>=2.0.0)", "cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
-brotli = ["brotlipy (>=0.6.0)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -888,7 +886,7 @@ six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
 [[package]]
 name = "webencodings"
@@ -928,8 +926,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "jaraco.itertools", "pytest-enabler (>=1.0.1)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
@@ -1056,7 +1054,6 @@ click = [
 ]
 codecov = [
     {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
-    {file = "codecov-2.1.12-py3.8.egg", hash = "sha256:782a8e5352f22593cbc5427a35320b99490eb24d9dcfa2155fd99d2b75cfb635"},
     {file = "codecov-2.1.12.tar.gz", hash = "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"},
 ]
 colorama = [
@@ -1232,8 +1229,8 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.18.1-py2.py3-none-any.whl", hash = "sha256:02226e69564ebca1a070bd1f046af866aa1c318dbc430027c50ab832ed2b73f2"},
-    {file = "pre_commit-2.18.1.tar.gz", hash = "sha256:5d445ee1fa8738d506881c5d84f83c62bb5be6b2838e32207433647e8e5ebe10"},
+    {file = "pre_commit-2.21.0-py2.py3-none-any.whl", hash = "sha256:e2f91727039fc39a92f58a588a25b87f936de6567eed4f0e673e0507edc75bad"},
+    {file = "pre_commit-2.21.0.tar.gz", hash = "sha256:31ef31af7e474a8d8995027fefdfcf509b5c913ff31f2015b4ec4beb26a6f658"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
@@ -1291,6 +1288,13 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ Django = ">=2.2"
 djangorestframework = ">=3.8"
 
 [tool.poetry.dev-dependencies]
-"bump2version" = "^1.0.1"
-"flake8" = "^4.0.1"
+bump2version = "^1.0.1"
+flake8 = "^4.0.1"
 black = "^22.3.0"
 codecov = "^2.1.12"
 django-debug-toolbar = "^3.2.4"
@@ -30,6 +30,9 @@ redis = "^4.2.2"
 tox = "^3.24.5"
 twine = "^4.0.0"
 xenon = "^0.9.0"
+
+[tool.black]
+line-length = 88
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/tests/test_encoder.py
+++ b/tests/tests/test_encoder.py
@@ -1,31 +1,44 @@
-import json
-
 import pytest
+from django.test.client import RequestFactory
 
 from idempotency_key.encoders import BasicKeyEncoder
 from idempotency_key.exceptions import MissingIdempotencyKeyError
 
 
 def test_basic_encoding():
-    class Request:
-        path_info = "/myURL/path/"
-        method = "POST"
-        body = json.dumps({"key": "value"}).encode("UTF-8")
-
-    request = Request()
+    request = RequestFactory().post(
+        "/myURL/path/", {"key": "value"}, "application/json"
+    )
     obj = BasicKeyEncoder()
     enc_key = obj.encode_key(request, "MyKey")
     assert enc_key == "da44e9b4dd5bc8e7853a43c8e8f2d2c2de4394f6614ab37dd5507b6f5988aac4"
 
 
 def test_basic_encoder_null_key():
-    class Request:
-        path_info = "/myURL/path/"
-        method = "POST"
-        body = json.dumps({"key": "value"}).encode("UTF-8")
-
-    request = Request()
+    request = RequestFactory().post(
+        "/myURL/path/", {"key": "value"}, "application/json"
+    )
     obj = BasicKeyEncoder()
     with pytest.raises(MissingIdempotencyKeyError) as e_info:
         obj.encode_key(request, None)
     assert e_info.value.args[0] == "Idempotency key cannot be None."
+
+
+def test_basic_encoder_uses_authorization_header():
+    request1 = RequestFactory().post(
+        "/myURL/path/",
+        {"key": "value"},
+        "application/json",
+        HTTP_AUTHORIZATION="Bearer 123",
+    )
+    request2 = RequestFactory().post(
+        "/myURL/path/",
+        {"key": "value"},
+        "application/json",
+        HTTP_AUTHORIZATION="Bearer 321",
+    )
+
+    encoder = BasicKeyEncoder()
+    key1 = encoder.encode_key(request1, "test-idempotency-key")
+    key2 = encoder.encode_key(request2, "test-idempotency-key")
+    assert key1 != key2

--- a/tests/tests/test_middleware.py
+++ b/tests/tests/test_middleware.py
@@ -128,7 +128,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={})
     def test_middleware_duplicate_request(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -158,7 +162,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": None})
     def test_middleware_duplicate_request_use_original_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -188,7 +196,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": status.HTTP_200_OK})
     def test_middleware_duplicate_request_use_different_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -217,7 +229,11 @@ class TestMiddlewareInclusive:
         )
 
     def test_middleware_duplicate_request_manual_override(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-manual"],
@@ -251,7 +267,11 @@ class TestMiddlewareInclusive:
         IDEMPOTENCY_KEY={"ENCODER_CLASS": "tests.tests.test_middleware.MyEncoder"}
     )
     def test_middleware_custom_encoder(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -288,7 +308,11 @@ class TestMiddlewareInclusive:
         one that does not to store any information.
         Therefore a 409 conflict should never occur and the key will never exist.
         """
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -317,7 +341,11 @@ class TestMiddlewareInclusive:
         )
 
     def test_idempotency_key_decorator(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -391,7 +419,11 @@ class TestMiddlewareInclusive:
         Test Django cache storage
         """
         cache.clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -424,7 +456,11 @@ class TestMiddlewareInclusive:
         }
     )
     def test_store_on_statuses_does_not_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -453,7 +489,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={"STORE_ON_STATUSES": [status.HTTP_201_CREATED]})
     def test_store_on_statuses_does_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -483,7 +523,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={"LOCK": {"ENABLE": False}})
     def test_no_locking_on_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -527,7 +571,11 @@ class TestMiddlewareInclusive:
         """
         caches["default"].clear()
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-with-my-cache"],
@@ -570,7 +618,11 @@ class TestMiddlewareInclusive:
         Tests @idempotency_key(cache_name='FiveMinuteCache') decorator
         """
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],

--- a/tests/tests/test_middleware_exempt.py
+++ b/tests/tests/test_middleware_exempt.py
@@ -92,7 +92,11 @@ class TestMiddlewareExempt:
 
     @override_settings(IDEMPOTENCY_KEY={})
     def test_middleware_duplicate_request(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -119,7 +123,11 @@ class TestMiddlewareExempt:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": None})
     def test_middleware_duplicate_request_use_original_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -146,7 +154,11 @@ class TestMiddlewareExempt:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": status.HTTP_200_OK})
     def test_middleware_duplicate_request_use_different_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -172,7 +184,11 @@ class TestMiddlewareExempt:
         )
 
     def test_middleware_duplicate_request_manual_override(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-manual"],
@@ -203,7 +219,11 @@ class TestMiddlewareExempt:
         IDEMPOTENCY_KEY={"ENCODER_CLASS": "tests.tests.test_middleware.MyEncoder"}
     )
     def test_middleware_custom_encoder(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -238,7 +258,11 @@ class TestMiddlewareExempt:
         one that does not to store any information.
         Therefore a 409 conflict should never occur and the key will never exist.
         """
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -264,7 +288,11 @@ class TestMiddlewareExempt:
         )
 
     def test_idempotency_key_decorator(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -335,7 +363,11 @@ class TestMiddlewareExempt:
         Test Django cache storage
         """
         cache.clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -366,7 +398,11 @@ class TestMiddlewareExempt:
         }
     )
     def test_store_on_statuses_does_not_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -393,7 +429,11 @@ class TestMiddlewareExempt:
 
     @override_settings(IDEMPOTENCY_KEY={"STORE_ON_STATUSES": [status.HTTP_201_CREATED]})
     def test_store_on_statuses_does_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -436,7 +476,11 @@ class TestMiddlewareExempt:
         """
         caches["default"].clear()
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-with-my-cache"],
@@ -477,7 +521,11 @@ class TestMiddlewareExempt:
         Tests @idempotency_key(cache_name='FiveMinuteCache') decorator
         """
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],

--- a/tests/tests/test_middleware_exempt_viewsets.py
+++ b/tests/tests/test_middleware_exempt_viewsets.py
@@ -94,7 +94,11 @@ class TestMiddlewareExemptViewSets:
 
     @override_settings(IDEMPOTENCY_KEY={})
     def test_middleware_duplicate_request(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -121,7 +125,11 @@ class TestMiddlewareExemptViewSets:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": None})
     def test_middleware_duplicate_request_use_original_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -148,7 +156,11 @@ class TestMiddlewareExemptViewSets:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": status.HTTP_200_OK})
     def test_middleware_duplicate_request_use_different_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -174,7 +186,11 @@ class TestMiddlewareExemptViewSets:
         )
 
     def test_middleware_duplicate_request_manual_override(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-manual"],
@@ -205,7 +221,11 @@ class TestMiddlewareExemptViewSets:
         IDEMPOTENCY_KEY={"ENCODER_CLASS": "tests.tests.test_middleware.MyEncoder"}
     )
     def test_middleware_custom_encoder(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -240,7 +260,11 @@ class TestMiddlewareExemptViewSets:
         that does not to store any information.
         Therefore a 409 conflict should never occur and the key will never exist.
         """
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -266,7 +290,11 @@ class TestMiddlewareExemptViewSets:
         )
 
     def test_idempotency_key_decorator(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -338,7 +366,11 @@ class TestMiddlewareExemptViewSets:
         Test Django cache storage
         """
         cache.clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -364,7 +396,11 @@ class TestMiddlewareExemptViewSets:
         )
 
     def test_nested_decorator(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
         response = client.post(
             self.urls["create-nested-decorator"],
             voucher_data,
@@ -389,7 +425,11 @@ class TestMiddlewareExemptViewSets:
         )
 
     def test_nested_decorator_exempt(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
         response = client.post(
             self.urls["create-nested-decorator-exempt"],
             voucher_data,
@@ -417,7 +457,11 @@ class TestMiddlewareExemptViewSets:
         }
     )
     def test_store_on_statuses_does_not_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -444,7 +488,11 @@ class TestMiddlewareExemptViewSets:
 
     @override_settings(IDEMPOTENCY_KEY={"STORE_ON_STATUSES": [status.HTTP_201_CREATED]})
     def test_store_on_statuses_does_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -484,7 +532,11 @@ class TestMiddlewareExemptViewSets:
         Tests @idempotency_key(cache_name='FiveMinuteCache') decorator where the cache
         name has not been configured under settings.CACHE
         """
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         with pytest.raises(InvalidCacheBackendError):
             client.post(
@@ -511,7 +563,11 @@ class TestMiddlewareExemptViewSets:
         """
         caches["default"].clear()
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-with-my-cache"],
@@ -552,7 +608,11 @@ class TestMiddlewareExemptViewSets:
         Tests @idempotency_key(cache_name='FiveMinuteCache') decorator
         """
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],

--- a/tests/tests/test_middleware_viewsets.py
+++ b/tests/tests/test_middleware_viewsets.py
@@ -133,7 +133,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={})
     def test_middleware_duplicate_request(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -161,7 +165,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": None})
     def test_middleware_duplicate_request_use_original_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -189,7 +197,11 @@ class TestMiddlewareInclusive:
 
     @override_settings(IDEMPOTENCY_KEY={"CONFLICT_STATUS_CODE": status.HTTP_200_OK})
     def test_middleware_duplicate_request_use_different_status_code(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -216,7 +228,11 @@ class TestMiddlewareInclusive:
         )
 
     def test_middleware_duplicate_request_manual_override(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-manual"],
@@ -248,7 +264,11 @@ class TestMiddlewareInclusive:
         IDEMPOTENCY_KEY={"ENCODER_CLASS": "tests.tests.test_middleware.MyEncoder"}
     )
     def test_middleware_custom_encoder(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -280,10 +300,15 @@ class TestMiddlewareInclusive:
     )
     def test_middleware_custom_storage(self, client):
         """
-        In this test to prove the new custom storage class is being used by creating one that does not to store any
-        information. Therefore a 409 conflict should never occur and the key will never exist.
+        In this test to prove the new custom storage class is being used by creating
+        one that does not to store any information. Therefore a 409 conflict should
+        never occur and the key will never exist.
         """
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -310,7 +335,11 @@ class TestMiddlewareInclusive:
         )
 
     def test_idempotency_key_decorator(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -383,7 +412,11 @@ class TestMiddlewareInclusive:
         Test Django cache storage
         """
         cache.clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -409,7 +442,11 @@ class TestMiddlewareInclusive:
         )
 
     def test_nested_decorator(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
         response = client.post(
             self.urls["create-nested-decorator"],
             voucher_data,
@@ -433,7 +470,11 @@ class TestMiddlewareInclusive:
         )
 
     def test_nested_decorator_exempt(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
         response = client.post(
             self.urls["create-nested-decorator-exempt"],
             voucher_data,
@@ -461,7 +502,11 @@ class TestMiddlewareInclusive:
         }
     )
     def test_store_on_statuses_does_not_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -490,7 +535,11 @@ class TestMiddlewareInclusive:
         IDEMPOTENCY_KEY={"STORAGE": {"STORE_ON_STATUSES": [status.HTTP_201_CREATED]}}
     )
     def test_store_on_statuses_does_store(self, client):
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],
@@ -527,10 +576,14 @@ class TestMiddlewareInclusive:
     )
     def test_middleware_invalid_cache_name(self, client):
         """
-        Tests @idempotency_key(cache_name='FiveMinuteCache') decorator where the cache name has not been configured
-        under settings.CACHE
+        Tests @idempotency_key(cache_name='FiveMinuteCache') decorator where the
+        cache name has not been configured under settings.CACHE
         """
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         with pytest.raises(InvalidCacheBackendError):
             client.post(
@@ -544,7 +597,8 @@ class TestMiddlewareInclusive:
         IDEMPOTENCY_KEY={
             "STORAGE": {
                 "CLASS": "idempotency_key.storage.CacheKeyStorage",
-                "CACHE_NAME": "SevenDayCache",  # This should be overridden by the decorator
+                # This should be overridden by the decorator:
+                "CACHE_NAME": "SevenDayCache",
             }
         }
     )
@@ -556,7 +610,11 @@ class TestMiddlewareInclusive:
         """
         caches["default"].clear()
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create-with-my-cache"],
@@ -587,7 +645,8 @@ class TestMiddlewareInclusive:
         IDEMPOTENCY_KEY={
             "STORAGE": {
                 "CLASS": "idempotency_key.storage.CacheKeyStorage",
-                "CACHE_NAME": "FiveMinuteCache",  # This should be overridden by the decorator
+                # This should be overridden by the decorator:
+                "CACHE_NAME": "FiveMinuteCache",
             }
         }
     )
@@ -596,7 +655,11 @@ class TestMiddlewareInclusive:
         Tests @idempotency_key(cache_name='FiveMinuteCache') decorator
         """
         caches["FiveMinuteCache"].clear()
-        voucher_data = {"id": 1, "name": "myvoucher0", "internal_name": "myvoucher0"}
+        voucher_data = {
+            "id": 1,
+            "name": "myvoucher0",
+            "internal_name": "myvoucher0",
+        }
 
         response = client.post(
             self.urls["create"],

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -36,7 +36,10 @@ urlpatterns = [
     path(r"views/create-custom-header/", views.create_custom_header),
     path(r"viewsets/get/", MyViewSet.as_view({"get": "get"})),
     path(r"viewsets/create/", MyViewSet.as_view({"post": "create"})),
-    path(r"viewsets/create-optional/", MyViewSet.as_view({"post": "create_optional"})),
+    path(
+        r"viewsets/create-optional/",
+        MyViewSet.as_view({"post": "create_optional"}),
+    ),
     path(r"views/create-manual-exempt-2/", views.create_manual_exempt_2),
     path(r"viewsets/create-manual/", MyViewSet.as_view({"post": "create_manual"})),
     path(r"viewsets/create-exempt/", MyViewSet.as_view({"post": "create_exempt"})),
@@ -64,7 +67,10 @@ urlpatterns = [
         r"viewsets/create-with-my-cache/",
         MyViewSet.as_view({"post": "create_with_my_cache"}),
     ),
-    path(r"viewsets/create-nested-decorator/", MyViewSet2.as_view({"post": "create"})),
+    path(
+        r"viewsets/create-nested-decorator/",
+        MyViewSet2.as_view({"post": "create"}),
+    ),
     path(
         r"viewsets/create-nested-decorator-exempt/",
         MyViewSet2Exempt.as_view({"post": "create"}),

--- a/tests/views.py
+++ b/tests/views.py
@@ -13,14 +13,16 @@ from idempotency_key.utils import idempotency_key_exists
 @api_view(["GET"])
 def get(request, *args, **kwargs):
     return Response(
-        status=200, data={"idempotency_key_exempt": request.idempotency_key_exempt}
+        status=200,
+        data={"idempotency_key_exempt": request.idempotency_key_exempt},
     )
 
 
 @api_view(["POST"])
 def create_no_decorators(request, *args, **kwargs):
     return Response(
-        status=201, data={"idempotency_key_exempt": request.idempotency_key_exempt}
+        status=201,
+        data={"idempotency_key_exempt": request.idempotency_key_exempt},
     )
 
 
@@ -28,7 +30,8 @@ def create_no_decorators(request, *args, **kwargs):
 @api_view(["POST"])
 def create_exempt(request, *args, **kwargs):
     return Response(
-        status=201, data={"idempotency_key_exempt": request.idempotency_key_exempt}
+        status=201,
+        data={"idempotency_key_exempt": request.idempotency_key_exempt},
     )
 
 

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -16,18 +16,21 @@ class MyViewSet(ViewSet):
 
     def get(self, request, *args, **kwargs):
         return Response(
-            status=200, data={"idempotency_key_exempt": request.idempotency_key_exempt}
+            status=200,
+            data={"idempotency_key_exempt": request.idempotency_key_exempt},
         )
 
     def create_no_decorators(self, request, *args, **kwargs):
         return Response(
-            status=201, data={"idempotency_key_exempt": request.idempotency_key_exempt}
+            status=201,
+            data={"idempotency_key_exempt": request.idempotency_key_exempt},
         )
 
     @idempotency_key_exempt
     def create_exempt(self, request, *args, **kwargs):
         return Response(
-            status=201, data={"idempotency_key_exempt": request.idempotency_key_exempt}
+            status=201,
+            data={"idempotency_key_exempt": request.idempotency_key_exempt},
         )
 
     @idempotency_key
@@ -88,8 +91,8 @@ class ViewSetBase(MyModelViewSet):
         return super().create(request, *args, **kwargs)
 
 
-# NOTE: the base classes must be specified in the correct order where the decorators appear in the first base class
-# or they will not be detected by the middleware.
+# NOTE: the base classes must be specified in the correct order where the decorators
+# appear in the first base class or they will not be detected by the middleware.
 class MyViewSet2(ViewSetBase, MyMixin):
     pass
 
@@ -100,7 +103,7 @@ class ViewSetBaseExempt(MyModelViewSet):
         return super().create(request, *args, **kwargs)
 
 
-# NOTE: the base classes must be specified in the correct order where the decorators appear in the first base class
-# or they will not be detected by the middleware.
+# NOTE: the base classes must be specified in the correct order where the decorators
+# appear in the first base class or they will not be detected by the middleware.
 class MyViewSet2Exempt(ViewSetBaseExempt, MyMixin):
     pass


### PR DESCRIPTION
Thanks for great library YoyoTeam first of all! :)

This PR adds Authorisation header to the BasicKeyEncoder. It makes the library more secure.
If the authorisation header is not added to the key it is possible to bypass Authrization logic in case if the attacker knows or can predict the idempotency key used and knows (can predict the URL and the body payload). Without this fix the attacker can omit sending Auhtorisation header and receive access to the previously saved response. Even though this scenario is highly  unlikely, for some type of apps it can carry certain risks.

Unfortunately, I was unable to run pre-commit locally without upgrading to the latest version. I also upgraded pre-commit dependencies as part of this MR.