### PR TITLE
feat(parallel-requests): implement conflict on handling of parallel requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ To solve this the client sends a key in the request header that uniquely identif
 current operation so that if the server has already created object then it will not be
 recreated.
 
+The code tries to implement the [pre-RFC IETF spec for this
+feature](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/).
+
 This package allows API calls to opt-in or opt-out of using idempotency keys by default.
 There is also an option that allows the client to choose to use idempotency keys if the
 key is present in the header.
 
-If the request has previously succeeded then the original data will be returned and
-nothing new is created.
+If the request has previously succeeded then the original response data and status will be
+returned and nothing new is created. If the original request (as determined by the key) is
+still in-flight, 409 ("Conflict") is returned.
 
 ## Requirements
 
@@ -138,6 +142,13 @@ IDEMPOTENCY_KEY = {
         # This can be overriden using the @idempotency_key(cache_name='MyCacheName')
         # view/viewset function decorator.
         'CACHE_NAME': 'default',
+
+
+        # An upper bound, in seconds, of request handling time.
+        # For the purposes of conflict detection, the middleware keeps track of
+        # requests in flight. These requests will be forgotten after
+        # 'INCOMPLETE_TTL' seconds.
+        'INCOMPLETE_TTL': 30,
 
         # When the response is to be stored you have the option of deciding when this
         # happens based on the responses status code. If the response status code

--- a/idempotency_key/exceptions.py
+++ b/idempotency_key/exceptions.py
@@ -1,6 +1,6 @@
 from django.http import JsonResponse
 
-from idempotency_key import status
+from idempotency_key import status, utils
 
 
 class MissingIdempotencyKeyError(Exception):
@@ -33,3 +33,15 @@ def resource_locked(request, exception, *args, **kwargs):
     """
     data = {"error": "Resource Locked (423)"}
     return JsonResponse(data, status=status.HTTP_423_LOCKED)
+
+
+def conflict(request, exception, *args, **kwargs):
+    """
+    Generic 409 error handler.
+    """
+    status_code = utils.get_conflict_code()
+    if status_code == status.HTTP_409_CONFLICT:
+        data = {"error": "Conflict (409)"}
+    else:
+        data = {"error": f"({status_code})"}
+    return JsonResponse(data, status=status_code)

--- a/idempotency_key/storage.py
+++ b/idempotency_key/storage.py
@@ -1,16 +1,42 @@
 import abc
-import pickle
 from collections import defaultdict
+import time
 from typing import Tuple
 
 from django.core.cache import caches
+from django.http.response import HttpResponse
+
+
+class CachedHttpResponse:
+    def __init__(self, value: object):
+        self._response = value
+        self._mtime = time.time()
+
+    @property
+    def response_and_mtime(self):
+        return self._response, self._mtime
+
+    @response_and_mtime.setter
+    def response_and_mtime(self, value: object):
+        if not isinstance(value, HttpResponse):
+            raise ValueError("The value must be an instance of HttpResponse")
+        self._response = value
+        self._mtime = time.time()
 
 
 class IdempotencyKeyStorage(object):
     @abc.abstractmethod
+    def __init__(self, ttl: int):
+        """
+        Create a new store.
+        :param ttl: The maximum number of seconds that the store will retain incomplete entries
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def store_data(self, cache_name: str, encoded_key: str, response: object) -> None:
         """
-        called when data should be stored in the storage medium
+        Store date to the store using the specified key.
         :param cache_name: The name of the cache to use defined in settings under CACHES
         :param encoded_key: the key used to store the response data under
         :param response: The response data to store
@@ -21,10 +47,19 @@ class IdempotencyKeyStorage(object):
     @abc.abstractmethod
     def retrieve_data(self, cache_name: str, encoded_key: str) -> Tuple[bool, object]:
         """
-        Retrieve data from the sore using the specified key.
+        Retrieve data from the store using the specified key.
         :param cache_name: The name of the cache to use defined in settings under CACHES
         :param encoded_key: The key that was used to store the response data
         :return: the response data
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def delete_data(self, cache_name: str, encoded_key: str) -> None:
+        """
+        Delete data from the store using the specified key.
+        :param cache_name: The name of the cache to use defined in settings under CACHES
+        :param encoded_key: The key that was used to store the response data
         """
         raise NotImplementedError
 
@@ -42,18 +77,32 @@ class IdempotencyKeyStorage(object):
 
 
 class MemoryKeyStorage(IdempotencyKeyStorage):
-    def __init__(self):
+    def __init__(self, ttl: int):
+        self.ttl = ttl
         self.idempotency_key_cache_data = defaultdict(dict)
 
     def store_data(self, cache_name: str, encoded_key: str, response: object) -> None:
-        self.idempotency_key_cache_data[cache_name][encoded_key] = response
+        cached_response = CachedHttpResponse(response)
+        self.idempotency_key_cache_data[cache_name][encoded_key] = cached_response
 
     def retrieve_data(self, cache_name: str, encoded_key: str) -> Tuple[bool, object]:
-        the_cache = self.idempotency_key_cache_data.get(cache_name)
-        if the_cache and encoded_key in the_cache.keys():
-            return True, the_cache[encoded_key]
+        the_cache = self.idempotency_key_cache_data[cache_name]
+        if the_cache is None or encoded_key not in the_cache:
+            return False, None
 
-        return False, None
+        response, mtime = the_cache[encoded_key].response_and_mtime
+        if response is None and mtime + self.ttl < time.time():
+            # Incomplete value expired, delete it and pretend that it was never here.
+            del the_cache[encoded_key]
+            return False, None
+
+        return True, response
+
+    def delete_data(self, cache_name: str, encoded_key: str) -> None:
+        the_cache = self.idempotency_key_cache_data[cache_name]
+
+        if the_cache and encoded_key in the_cache:
+            del the_cache[encoded_key]
 
     @staticmethod
     def validate_storage(name: str):
@@ -61,16 +110,28 @@ class MemoryKeyStorage(IdempotencyKeyStorage):
 
 
 class CacheKeyStorage(IdempotencyKeyStorage):
+    def __init__(self, ttl: int):
+        self.ttl = ttl
+
     def store_data(self, cache_name: str, encoded_key: str, response: object) -> None:
-        str_response = pickle.dumps(response)
-        caches[cache_name].set(encoded_key, str_response)
+        cached_response = CachedHttpResponse(response)
+        caches[cache_name].set(encoded_key, cached_response)
 
     def retrieve_data(self, cache_name: str, encoded_key: str) -> Tuple[bool, object]:
-        if encoded_key in caches[cache_name]:
-            str_response = caches[cache_name].get(encoded_key)
-            return True, pickle.loads(str_response)
+        if encoded_key not in caches[cache_name]:
+            return False, None
 
-        return False, None
+        response, mtime = caches[cache_name].get(encoded_key).response_and_mtime
+        if response is None and mtime + self.ttl < time.time():
+            # Incomplete value expired, delete it and pretend that it was never here.
+            caches[cache_name].delete(encoded_key)
+            return False, None
+
+        return True, response
+
+    def delete_data(self, cache_name: str, encoded_key: str):
+        if encoded_key in caches[cache_name]:
+            caches[cache_name].delete(encoded_key)
 
     @staticmethod
     def validate_storage(name: str):

--- a/idempotency_key/utils.py
+++ b/idempotency_key/utils.py
@@ -40,6 +40,10 @@ def get_storage_class():
     )
 
 
+def get_storage_incomplete_ttl():
+    return get_storage_settings().get("INCOMPLETE_TTL", 30)
+
+
 def get_storage_cache_name():
     return get_storage_settings().get("CACHE_NAME", "default")
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 import debug_toolbar
 from django.conf.urls import include
 from django.contrib import admin


### PR DESCRIPTION
(**NOTE**: I have not yet fixed the tests to support the new semantics. If there is appetite
to merge this change, I will work on fixing the tests and make it more merge-ready)

Before this change, the semantics of handling duplicate
requests issues one after another (with the same key) were
as follows:
- If the handling of the first-time request has completed
  before the duplicate has arrived, the duplicate would
  not be handled, and the response of the first-time
  request would be returned. The HTTP status of the
  response to the duplicate request would always be
  409/Conflict. (See test_middleware_duplicate_request()
  in the tests).
- If the duplicate request arrived while the first-time
  one is still being processed, it would be handled
  independently, therefore breaking the idempotency
  guarantee.

This behavior doesn't align with the recently published
idempotency tokens pre-RFC [1] by IETF. The behavior
dictated by the spec (section 2.6) is as follows:
- If the duplicate arrives after the first-time request has
  completed, don't process the duplicate and return
  the response and _the HTTP status_ of the first request.
- If the duplicate arrives while the first-time request is
  still being handled, don't process it and return
  409/Conflict immediately.

This commit aligns the behavior with the spec.

[1] https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/